### PR TITLE
Rename and reorganize outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 main.out:
-	/usr/local/opt/llvm/bin/clang++ main.cpp -gdwarf-4 -o main.out
+	@echo "Compiling testcase..."
+	clang++ main.cpp -gdwarf-4 -o testcase.out
+	cp testcase.out.dSYM/Contents/Resources/DWARF/testcase.out testcase.dwarf
 
 clean:
-	rm main.out
+	rm -r testcase.out testcase.dwarf testcase.out.dSYM


### PR DESCRIPTION
Rename main.out as testcase.out. Copy DWARF content to top directory for
easier access.